### PR TITLE
删除trailing space & 解决missing job的问题

### DIFF
--- a/GFWeather.py
+++ b/GFWeather.py
@@ -10,11 +10,8 @@ from bs4 import BeautifulSoup
 
 import city_dict
 
-# DEBUG mode, if on, it will send a test message every 2 minutes
-DEBUG = False
-
 # fire the job again if it was missed within GRACE_PERIOD
-GRACE_PERIOD = 15*60
+GRACE_PERIOD = 15 * 60
 
 class GFWeather:
     headers = {
@@ -125,8 +122,8 @@ class GFWeather:
         scheduler.add_job(self.start_today_info, 'cron', hour=self.alarm_hour,
                           minute=self.alarm_minute, misfire_grace_time=GRACE_PERIOD)
         # 每隔 2 分钟发送一条数据用于测试。
-        if DEBUG:
-            scheduler.add_job(self.start_today_info, 'interval', seconds=120)
+#         if DEBUG:
+#             scheduler.add_job(self.start_today_info, 'interval', seconds=120)
         scheduler.start()
 
     def start_today_info(self, is_test=False):

--- a/GFWeather.py
+++ b/GFWeather.py
@@ -10,6 +10,11 @@ from bs4 import BeautifulSoup
 
 import city_dict
 
+# DEBUG mode, if on, it will send a test message every 2 minutes
+DEBUG = False
+
+# fire the job again if it was missed within GRACE_PERIOD
+GRACE_PERIOD = 15*60
 
 class GFWeather:
     headers = {
@@ -117,9 +122,11 @@ class GFWeather:
         # 定时任务
         scheduler = BlockingScheduler()
         # 每天9：30左右给女朋友发送每日一句
-        scheduler.add_job(self.start_today_info, 'cron', hour=self.alarm_hour, minute=self.alarm_minute)
+        scheduler.add_job(self.start_today_info, 'cron', hour=self.alarm_hour,
+                          minute=self.alarm_minute, misfire_grace_time=GRACE_PERIOD)
         # 每隔 2 分钟发送一条数据用于测试。
-        # scheduler.add_job(self.start_today_info, 'interval', seconds=120)
+        if DEBUG:
+            scheduler.add_job(self.start_today_info, 'interval', seconds=120)
         scheduler.start()
 
     def start_today_info(self, is_test=False):
@@ -181,7 +188,6 @@ class GFWeather:
             conentJson = resp.json()
             content = conentJson.get('content')
             note = conentJson.get('note')
-            # print(f"{content}\n{note}")
             return f"{content}\n{note}\n"
         else:
             print("没有获取到数据")

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ def get_dictum_info(self):
 有英文和中文翻译，例如：
 > When you finally get your own happiness, you will understand the
 > previous sadness is a kind of treasure, which makes you better to hold
-> and cherish the people you love.  
+> and cherish the people you love.
 > 等你获得真正属于你的幸福之后，你就会明白一起的伤痛其实是一种财富，它让你学会更好地去把握和珍惜你爱的人。
 
 代码实现 ：
@@ -113,7 +113,7 @@ def get_lovelive_info(self):
     else:
         print('每日一句获取失败')
         return None
-```  
+```
 
 #### 3. 获取今日天气 。
 天气数据来源：[SOJSON][7]
@@ -136,7 +136,7 @@ itchat.auto_login()
 itchat.send(today_msg, toUserName=name_uuid)
 ```
 
-## 项目配置 
+## 项目配置
 
 ### 安装依赖
 
@@ -187,13 +187,13 @@ python run.py
 #Ctrl+A+D 退出 Screen 窗口
 ```
 
-### 3.使用 Docker  
+### 3.使用 Docker
 ```
 sudo docker build -t everydaywechat .
 sudo docker run --name '项目所在地址'
 # 扫码登陆
-#Ctrl+P+Q 退出容器  
-```  
+#Ctrl+P+Q 退出容器
+```
 
 ## 最后
 项目地址：[https://github.com/sfyc23/EverydayWechat](https://github.com/sfyc23/EverydayWechat)  


### PR DESCRIPTION
到底有多少人在用文本编辑器写代码。。这么多trailing space.

另外，我本人在跑代码的时候，每次job都被miss掉了。
症状如下：
~~~
Run time of job "gfweather.start_today_info (trigger: cron[hour='8', minute='30'], next run at: 2019-06-09 08:30:00 HKT)" was missed by 0:00:02.483505
Run time of job "gfweather.start_today_info (trigger: cron[hour='8', minute='30'], next run at: 2019-06-10 08:30:00 HKT)" was missed by 0:00:02.515792
~~~
所以引入fire_grace_period这个参数来防止job被miss掉的问题.
另：在最新的apscheduler里面，使用这个参数的方式和之前不太一样。参考apscheduler源码。

参考：
http://www.vuln.cn/9121