### PR TITLE
修改命令行显示二维码部分enableCmdQR数值为1

### DIFF
--- a/everyday_wechat/main.py
+++ b/everyday_wechat/main.py
@@ -75,7 +75,7 @@ def is_online(auto_login=False):
             itchat.run(blockThread=True)
         else:
             # 命令行显示登录二维码。
-            itchat.auto_login(enableCmdQR=2, hotReload=hotReload, loginCallback=loginCallback,
+            itchat.auto_login(enableCmdQR=1, hotReload=hotReload, loginCallback=loginCallback,
                               exitCallback=exitCallback)
             itchat.run(blockThread=True)
         if _online():


### PR DESCRIPTION
尝试了Windows bash及CentOS与Ubuntu系统shell，该选项默认为1比较合适，均可正常显示